### PR TITLE
removed the line calling CST a beta feature

### DIFF
--- a/dashboard2/publishwebsite/clientsidetranslation.md
+++ b/dashboard2/publishwebsite/clientsidetranslation.md
@@ -1,6 +1,6 @@
-# Client-Side Translation
+# Basic publishing: Client-Side Translation
 
-**CST is currently in a live-tested beta phase.**
+**Basic publishing is currently the recommended publishing method.**
 
 ## What is CST?
 


### PR DESCRIPTION
We should probably release this changeset ASAP as Crest is now the default publishing method we are selling, not a beta. Then, next week, I could work on re-writing the entire publishing section to better reflect this.