### PR TITLE
Submodules in RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,10 @@
 # Required
 version: 2
 
+submodules:
+  include: all
+  recursive: true
+
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04


### PR DESCRIPTION
ReadTheDocs required the submodules to be declared in the config file, and since this block was left out, the tech reference wasn't built.